### PR TITLE
Updates for Firefox 69, fixes for new tab page and color fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.1
+VERSION=1.2
 
 all:
 	zip -r -FS firefox-breeze-dark-$(VERSION).xpi manifest.json background.js kde-logo-48x48.png kde-logo-96x96.png

--- a/background.js
+++ b/background.js
@@ -1,16 +1,51 @@
 var theme = {
     colors: {
-        accentcolor: "#31363b",
-        textcolor: "#ffffff",
+        bookmark_text: "#eff0f1",
         
-        toolbar: "#40454a",
-        tab_line: "#2478c8",
+        button_background_active: "#3daee9",
+        button_background_hover: "#2e3b43",
+        icons: "#eff0f1",
+        icons_attention: "#3daee9",
         
-        toolbar_field: "#31363b",
-        toolbar_field_text: "#ffffff",
+        frame: "#31363b",
+        frame_inactive: "#2b3034",
+        
+        ntp_background: "#232629",
+        ntp_text: "#eff0f1",
         
         popup: "#31363b",
-        popup_text: "#ffffff"
+        popup_text: "#eff0f1",
+        popup_border: "#909396",
+        popup_highlight: "#3daee9",
+        popup_highlight_text: "#eff0f1",
+        popup_text: "#eff0f1",
+        
+        sidebar: "#232629",
+        sidebar_border: "#909396",
+        sidebar_highlight: "#3daee9",
+        sidebar_highlight_text: "#eff0f1",
+        sidebar_text: "#eff0f1",
+        
+        tab_background_separator: "#909396",
+        tab_background_text: "#eff0f1",
+        tab_line: "#3daee9",
+        tab_loading: "#f67400",
+        tab_selected: "#31363b",
+        tab_text: "#eff0f1",
+        
+        toolbar: "#31363b",
+        toolbar_bottom_separator: "#909396",
+        toolbar_field: "#232629",
+        toolbar_field_border: "#909396",
+        toolbar_field_border_focus: "#3daee9",
+        toolbar_field_focus: "#232629",
+        toolbar_field_highlight: "#3daee9",
+        toolbar_field_highlight_text: "#eff0f1",
+        toolbar_field_separator: "#909396",
+        toolbar_field_text: "#eff0f1",
+        toolbar_field_text_focus: "#eff0f1",
+        toolbar_top_separator: "#31363b",
+        toolbar_vertical_separator: "#909396"
     }
 };
 

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
     "name": "Breeze dark",
     "description": "(firefox >= 60.0) Better graphical integration with KDE plasma breeze dark",
-    "version": "1.1",
+    "version": "1.2",
 
     "icons": {
         "48":"kde-logo-48x48.png",


### PR DESCRIPTION
Fixes #1 

Copied from body of 8413159f2e8ec77295959818d4b1fa394eb62a31:

1. accentcolor and textcolor are being deprecated in Firefox 69. Updated
them to their replacements.

2. I looked at the breeze dark theme files to figure out what colors are
being used. Lots of colors used in the theme were *slightly* off, mainly
text colors. When deciding on what colors corresponded to what, I used
Konqueror, Dolphin, and Konsole as a guide.

3. Fixed the new tab background. It's now properly dark.

4. Arranged the entries in the same order they are here:
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/theme